### PR TITLE
feat(server): merge image with frame in backend

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,9 @@
         "@babel/node": "^7.10.5",
         "@babel/preset-env": "^7.10.4",
         "@babel/preset-typescript": "^7.10.4",
+        "@types/cors": "^2.8.6",
         "@types/express": "^4.17.7",
+        "@types/merge-images": "^1.1.2",
         "@types/node": "^14.0.23",
         "@types/winston": "^2.4.4",
         "nodemon": "^2.0.4",
@@ -19,6 +21,7 @@
     },
     "dependencies": {
         "body-parser": "^1.19.0",
+        "canvas": "^2.6.1",
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "ts-node": "^8.10.2",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,14 +1,17 @@
 import express from 'express';
-import bodParser from 'body-parser';
+import bodyParser from 'body-parser';
+import cors from 'cors';
 import imageRouter from './routes/imageRouter';
 
 const app = express();
 
-app.use(bodParser.urlencoded({ extended: true }));
-app.use(bodParser.json());
+app.use(cors());
+app.use(bodyParser.json({ limit: "50mb" }));
+app.use(bodyParser.urlencoded({ limit: "50mb", extended: true, parameterLimit: 50000 }));
+
 app.use('/image', imageRouter);
 
-app.get('/', (req, res) => {
+app.get('/', (req: express.Request, res: express.Response) => {
   res.send('Welcome To Backend, Let\'S Create Image');
 });
 

--- a/server/src/controllers/mergeImageWithFrame.ts
+++ b/server/src/controllers/mergeImageWithFrame.ts
@@ -1,5 +1,37 @@
+import express from 'express';
+import { createCanvas, loadImage } from "canvas";
 import logger from '../utils/logger';
 
-export const mergeImageWithFrame = (req: Express.Request, res:Express.Response) => {
-  logger.info('Lets merge Image');
+const createImageUrlFromCanvas = async (userImage: string, frameImage: string) => {
+  try {
+    
+  const loadUserImage = await loadImage(userImage);
+  const loadFrameImage = await loadImage(frameImage);
+
+  const maxWidth = Math.max(loadUserImage.width, loadFrameImage.width);
+  const maxHeight = Math.max(loadUserImage.width, loadFrameImage.height);
+
+  const canvas = createCanvas(maxWidth,maxHeight);
+  const ctx = canvas.getContext('2d');
+
+  ctx.drawImage(loadFrameImage, 0,0, maxWidth, maxHeight);
+  ctx.globalCompositeOperation='destination-over';
+  ctx.drawImage(loadUserImage, 10, 10, maxWidth - 50, maxHeight - 50);
+
+  return canvas.toDataURL('image/png');
+  } catch (err) {
+    logger.error(`Error in createImageFromCanvas: ${err}`);
+    return err;
+  }
+};
+
+export const mergeImageWithFrame = async (req: express.Request, res: express.Response) => {
+  const { userImage, frameImage} = req.body;
+  try {
+    const framedImage = await createImageUrlFromCanvas(userImage, frameImage);
+    res.send({data: frameImage});
+  } catch (err) {
+    logger.error(`Error in mergeImageWithFrame: ${err}`);
+    res.send({data: err});
+  }
 };


### PR DESCRIPTION
# Description
-  Using the canvas library to merge two images in the backend and send back the image to the frontend for download.
- Took max height and width among images and set the frame and uploaded images for merge.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] Upload GIF/Video for frontend PR
- [x] Up-to-date with master
- [x] All the commits are squashed into the single commit.

# Screenshots/GIFs:
![Capture](https://user-images.githubusercontent.com/6883790/88205813-ed6a7c80-cc6a-11ea-8f2b-672c57b8ac5c.PNG)

